### PR TITLE
[#220] Do not force atom keys in body params

### DIFF
--- a/lib/pipedrive/deals.ex
+++ b/lib/pipedrive/deals.ex
@@ -26,7 +26,7 @@ defmodule Pipedrive.Deals do
   """
   @impl Pipedrive.RESTEntity
   @spec create(map(), Keyword.t()) :: API.response()
-  def create(%{title: _} = body_params, opts \\ []) do
+  def create(body_params, opts \\ []) do
     API.post("/deals", body_params, opts)
   end
 
@@ -37,8 +37,7 @@ defmodule Pipedrive.Deals do
   """
   @impl Pipedrive.RESTEntity
   @spec update(map(), Keyword.t()) :: API.response()
-  def update(%{id: _id} = body_params, opts \\ []) do
-    {id, body_params} = Map.pop(body_params, :id)
+  def update(id, body_params, opts \\ []) do
     API.put("/deals/#{id}", body_params, opts)
   end
 

--- a/lib/pipedrive/deals.ex
+++ b/lib/pipedrive/deals.ex
@@ -20,7 +20,7 @@ defmodule Pipedrive.Deals do
   end
 
   @doc """
-  Create an deal. Accepts a map of params (`body`), of which `title` is required.
+  Create a deal. Accepts a map of params (`body`), of which `title` is required.
 
   [Pipedrive API docs](#{api_docs_base_url()}/Deals/post_deals)
   """
@@ -35,7 +35,7 @@ defmodule Pipedrive.Deals do
   end
 
   @doc """
-  Update a deal. Accepts a map of params (`body`).
+  Update a deal. Accepts an id and a map of params (`body`) to be updated.
 
   [Pipedrive API docs](#{api_docs_base_url()}/Deals/put_deals_id)
   """

--- a/lib/pipedrive/deals.ex
+++ b/lib/pipedrive/deals.ex
@@ -26,12 +26,16 @@ defmodule Pipedrive.Deals do
   """
   @impl Pipedrive.RESTEntity
   @spec create(map(), Keyword.t()) :: API.response()
-  def create(body_params, opts \\ []) do
+  def create(body_params, opts \\ [])
+  def create(%{title: _} = body_params, opts), do: do_create(body_params, opts)
+  def create(%{"title" => _} = body_params, opts), do: do_create(body_params, opts)
+
+  defp do_create(body_params, opts) do
     API.post("/deals", body_params, opts)
   end
 
   @doc """
-  Update a deal. Accepts a map of params (`body`), of which `id` is required.
+  Update a deal. Accepts a map of params (`body`).
 
   [Pipedrive API docs](#{api_docs_base_url()}/Deals/put_deals_id)
   """

--- a/lib/pipedrive/organizations.ex
+++ b/lib/pipedrive/organizations.ex
@@ -26,7 +26,7 @@ defmodule Pipedrive.Organizations do
   """
   @impl Pipedrive.RESTEntity
   @spec create(map(), Keyword.t()) :: API.response()
-  def create(%{name: _} = body_params, opts \\ []) do
+  def create(body_params, opts \\ []) do
     API.post("/organizations", body_params, opts)
   end
 
@@ -37,8 +37,7 @@ defmodule Pipedrive.Organizations do
   """
   @impl Pipedrive.RESTEntity
   @spec update(map(), Keyword.t()) :: API.response()
-  def update(%{id: _id} = body_params, opts \\ []) do
-    {id, body_params} = Map.pop(body_params, :id)
+  def update(id, body_params, opts \\ []) do
     API.put("/organizations/#{id}", body_params, opts)
   end
 

--- a/lib/pipedrive/organizations.ex
+++ b/lib/pipedrive/organizations.ex
@@ -26,12 +26,16 @@ defmodule Pipedrive.Organizations do
   """
   @impl Pipedrive.RESTEntity
   @spec create(map(), Keyword.t()) :: API.response()
-  def create(body_params, opts \\ []) do
+  def create(body_params, opts \\ [])
+  def create(%{name: _} = body_params, opts), do: do_create(body_params, opts)
+  def create(%{"name" => _} = body_params, opts), do: do_create(body_params, opts)
+
+  defp do_create(body_params, opts) do
     API.post("/organizations", body_params, opts)
   end
 
   @doc """
-  Updates an organization. Accepts a map of params (`body`) of which `id` is required.
+  Updates an organization. Accepts a map of params (`body`).
 
   [Pipedrive API docs](#{api_docs_base_url()}Organizations/put_organizations_id)
   """

--- a/lib/pipedrive/organizations.ex
+++ b/lib/pipedrive/organizations.ex
@@ -35,7 +35,7 @@ defmodule Pipedrive.Organizations do
   end
 
   @doc """
-  Updates an organization. Accepts a map of params (`body`).
+  Updates an organization. Accepts an id and a map of params (`body`) to be updated.
 
   [Pipedrive API docs](#{api_docs_base_url()}Organizations/put_organizations_id)
   """

--- a/lib/pipedrive/persons.ex
+++ b/lib/pipedrive/persons.ex
@@ -20,7 +20,7 @@ defmodule Pipedrive.Persons do
   end
 
   @doc """
-  Create an deal. Accepts a map of params (`body`), of which `name` is required.
+  Create a person. Accepts a map of params (`body`), of which `name` is required.
 
   [Pipedrive API docs](#{api_docs_base_url()}/Persons/post_persons)
   """
@@ -35,7 +35,7 @@ defmodule Pipedrive.Persons do
   end
 
   @doc """
-  Update a person. Accepts a map of params (`body`).
+  Update a person. Accepts an id and a map of params to be updated.
 
   [Pipedrive API docs](#{api_docs_base_url()}/Persons/put_person_id)
   """

--- a/lib/pipedrive/persons.ex
+++ b/lib/pipedrive/persons.ex
@@ -26,12 +26,16 @@ defmodule Pipedrive.Persons do
   """
   @impl Pipedrive.RESTEntity
   @spec create(map(), Keyword.t()) :: API.response()
-  def create(body_params, opts \\ []) do
+  def create(body_params, opts \\ [])
+  def create(%{name: _} = body_params, opts), do: do_create(body_params, opts)
+  def create(%{"name" => _} = body_params, opts), do: do_create(body_params, opts)
+
+  defp do_create(body_params, opts) do
     API.post("/persons", body_params, opts)
   end
 
   @doc """
-  Update a person. Accepts a map of params (`body`), of which `id` is required.
+  Update a person. Accepts a map of params (`body`).
 
   [Pipedrive API docs](#{api_docs_base_url()}/Persons/put_person_id)
   """

--- a/lib/pipedrive/persons.ex
+++ b/lib/pipedrive/persons.ex
@@ -26,7 +26,7 @@ defmodule Pipedrive.Persons do
   """
   @impl Pipedrive.RESTEntity
   @spec create(map(), Keyword.t()) :: API.response()
-  def create(%{name: _} = body_params, opts \\ []) do
+  def create(body_params, opts \\ []) do
     API.post("/persons", body_params, opts)
   end
 
@@ -37,8 +37,7 @@ defmodule Pipedrive.Persons do
   """
   @impl Pipedrive.RESTEntity
   @spec update(map(), Keyword.t()) :: API.response()
-  def update(%{id: _id} = body_params, opts \\ []) do
-    {id, body_params} = Map.pop(body_params, :id)
+  def update(id, body_params, opts \\ []) do
     API.put("/persons/#{id}", body_params, opts)
   end
 

--- a/lib/pipedrive/rest_entity.ex
+++ b/lib/pipedrive/rest_entity.ex
@@ -9,8 +9,8 @@ defmodule Pipedrive.RESTEntity do
   @callback create(map()) :: API.response()
   @callback create(map(), Keyword.t()) :: API.response()
 
-  @callback update(map()) :: API.response()
-  @callback update(map(), Keyword.t()) :: API.response()
+  @callback update(String.t(), map()) :: API.response()
+  @callback update(String.t(), map(), Keyword.t()) :: API.response()
 
   @callback delete(String.t()) :: API.response()
   @callback delete(String.t(), Keyword.t()) :: API.response()

--- a/test/pipedrive/persons_test.exs
+++ b/test/pipedrive/persons_test.exs
@@ -32,7 +32,7 @@ defmodule Pipedrive.Test.Persons do
       old_email = "gary@example.com"
       new_email = "g.doe1985@example.com"
       {:ok, %{"data" => %{"id" => id}}} = Persons.create(%{name: "Gary Doe", email: old_email})
-      {:ok, %{"data" => %{"id" => ^id}}} = Persons.update(%{id: id, email: new_email})
+      {:ok, %{"data" => %{"id" => ^id}}} = Persons.update(id, %{email: new_email})
 
       {:ok, %{"data" => data}} = Persons.list()
       assert Enum.find(data, &(get_email.(&1) == new_email))


### PR DESCRIPTION
I am removing pattern-matching on body params. The pattern-matching was done with atom keys. This is problematic because of how Pipedrive handles custom fields. Long story short, if you create a custom field called "datasource", the body params you send to populate this field and set a publication's name look like this:
```elixir
%{
  :name => "foo",
  "11c154eca3ede8d8c79dcf6ed404c60a248650ca" => "automated prod sync"
}
```

I would prefer to avoid creating atoms from random strings like that, and I would also like to avoid mixing up atom and string keys. The only remaining solution was to use only string keys.