### PR TITLE
CircleCI: Attempt to save/restore PLT cache for build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 2.1
 
 # commands (one or more steps) reused in many jobs
 commands:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,17 +4,7 @@ version: 2.1
 commands:
   # all caches include a version in their name (e.g. foo-cache-v1), the version is an arbitrary number
   # that can be incremented to invalidate a cache in case of errors or other unforeseen circumstances
-  save_plt_cache:
-    steps:
-      - run:
-          name: Version files for caches
-          command: elixir --version >> ELIXIR_VERSION
-      - save_cache:
-          name: Save PLT cache
-          key: plt-cache-v1-{{ checksum "ELIXIR_VERSION" }}
-          paths:
-            - /home/circleci/repo/priv/plts
-  restore_plt_cache:
+  run_dializer_with_cache:
     steps:
       - run:
           name: Version files for caches
@@ -22,6 +12,12 @@ commands:
       - restore_cache:
           name: Restore PLT cache
           key: plt-cache-v1-{{ checksum "ELIXIR_VERSION" }}
+      - run: time mix dialyzer --halt-exit-status
+      - save_cache:
+          name: Save PLT cache
+          key: plt-cache-v1-{{ checksum "ELIXIR_VERSION" }}
+          paths:
+            - /home/circleci/repo/priv/plts
 
 jobs:
   build:
@@ -39,8 +35,6 @@ jobs:
       - run: mix deps.get
       - run: mix compile --force --warnings-as-errors
       - run: mix credo
-      - restore_plt_cache
-      - run: time mix dialyzer --halt-exit-status
-      - save_plt_cache
+      - run_dializer_with_cache
       - run: mix coveralls
       - run: mix test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
       - run: mix compile --force --warnings-as-errors
       - run: mix credo
       - restore_plt_cache
-      - run: mix dialyzer --halt-exit-status
+      - run: time mix dialyzer --halt-exit-status
       - save_plt_cache
       - run: mix coveralls
       - run: mix test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,28 @@
 version: 2
+
+# commands (one or more steps) reused in many jobs
+commands:
+  # all caches include a version in their name (e.g. foo-cache-v1), the version is an arbitrary number
+  # that can be incremented to invalidate a cache in case of errors or other unforeseen circumstances
+  save_plt_cache:
+    steps:
+      - run:
+          name: Version files for caches
+          command: elixir --version >> ELIXIR_VERSION
+      - save_cache:
+          name: Save PLT cache
+          key: plt-cache-v1-{{ checksum "ELIXIR_VERSION" }}
+          paths:
+            - /home/circleci/repo/priv/plts
+  restore_plt_cache:
+    steps:
+      - run:
+          name: Version files for caches
+          command: elixir --version >> ELIXIR_VERSION
+      - restore_cache:
+          name: Restore PLT cache
+          key: plt-cache-v1-{{ checksum "ELIXIR_VERSION" }}
+
 jobs:
   build:
     environment:
@@ -15,6 +39,8 @@ jobs:
       - run: mix deps.get
       - run: mix compile --force --warnings-as-errors
       - run: mix credo
+      - restore_plt_cache
       - run: mix dialyzer --halt-exit-status
+      - save_plt_cache
       - run: mix coveralls
       - run: mix test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ commands:
       - restore_cache:
           name: Restore PLT cache
           key: plt-cache-v1-{{ checksum "ERLANG_VERSION" }}-{{ checksum "ELIXIR_VERSION" }}
-      - run: time mix dialyzer --halt-exit-status
+      - run: mix dialyzer --halt-exit-status
       - save_cache:
           name: Save PLT cache
           key: plt-cache-v1-{{ checksum "ERLANG_VERSION" }}-{{ checksum "ELIXIR_VERSION" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ commands:
     steps:
       - run:
           name: Version files for caches
-          command: elixir --version >> ELIXIR_VERSION
+          command: elixir --version > ELIXIR_VERSION
       - restore_cache:
           name: Restore PLT cache
           key: plt-cache-v1-{{ checksum "ELIXIR_VERSION" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,15 +7,18 @@ commands:
   run_dializer_with_cache:
     steps:
       - run:
-          name: Version files for caches
+          name: Store elixir version for PLT cache
           command: elixir --version > ELIXIR_VERSION
+      - run:
+          name: Store erlang version for PLT cache
+          command: erl -eval '{ok, Version} = file:read_file(filename:join([code:root_dir(), "releases", erlang:system_info(otp_release), "OTP_VERSION"])), io:fwrite(Version), halt().' -noshell > ERLANG_VERSION
       - restore_cache:
           name: Restore PLT cache
-          key: plt-cache-v1-{{ checksum "ELIXIR_VERSION" }}
+          key: plt-cache-v1-{{ checksum "ERLANG_VERSION" }}-{{ checksum "ELIXIR_VERSION" }}
       - run: time mix dialyzer --halt-exit-status
       - save_cache:
           name: Save PLT cache
-          key: plt-cache-v1-{{ checksum "ELIXIR_VERSION" }}
+          key: plt-cache-v1-{{ checksum "ERLANG_VERSION" }}-{{ checksum "ELIXIR_VERSION" }}
           paths:
             - /home/circleci/repo/priv/plts
 

--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,8 @@ erl_crash.dump
 # Ignore package tarball (built via "mix hex.build").
 pipedrive-*.tar
 
+# Ignore PLT files
+/priv/plts/*.plt
+/priv/plts/*.plt.hash
+
 SCRATCHPAD.ex

--- a/mix.exs
+++ b/mix.exs
@@ -22,7 +22,10 @@ defmodule Pipedrive.MixProject do
         "coveralls.html": :test
       ],
       test_coverage: [tool: ExCoveralls],
-      dialyzer: [plt_add_deps: true]
+      dialyzer: [
+        plt_add_deps: true,
+        plt_file: {:no_warn, "priv/plts/dialyzer.plt"}
+      ]
     ]
   end
 


### PR DESCRIPTION
**Trello Ticket** https://trello.com/c/MGZd35c6

Without the PLT cache a dializer run takes approx **3m43.637s** real time.

On a side note: The **user time** was **7m47.512s**. I wonder if thats due to multiple cores being used by the dialyzer?

<details>
  <summary>time mix dialyzer --halt-exit-status</summary>

```bash
time mix dialyzer --halt-exit-status
Finding suitable PLTs
Checking PLT...
[:credo, :dialyxir, :elixir, :ex_doc, :httpoison, :jason, :kernel, :logger, :stdlib]
Looking up modules in dialyxir_erlang-21.3.2_elixir-1.8.1_deps-dev.plt
Looking up modules in dialyxir_erlang-21.3.2_elixir-1.8.1.plt
Looking up modules in dialyxir_erlang-21.3.2.plt
Finding applications for dialyxir_erlang-21.3.2.plt
Finding modules for dialyxir_erlang-21.3.2.plt
Creating dialyxir_erlang-21.3.2.plt
Looking up modules in dialyxir_erlang-21.3.2.plt
Removing 4 modules from dialyxir_erlang-21.3.2.plt
Checking 14 modules in dialyxir_erlang-21.3.2.plt
Adding 175 modules to dialyxir_erlang-21.3.2.plt
Finding applications for dialyxir_erlang-21.3.2_elixir-1.8.1.plt
Finding modules for dialyxir_erlang-21.3.2_elixir-1.8.1.plt
Copying dialyxir_erlang-21.3.2.plt to dialyxir_erlang-21.3.2_elixir-1.8.1.plt
Looking up modules in dialyxir_erlang-21.3.2_elixir-1.8.1.plt
Checking 189 modules in dialyxir_erlang-21.3.2_elixir-1.8.1.plt
Adding 231 modules to dialyxir_erlang-21.3.2_elixir-1.8.1.plt
Finding applications for dialyxir_erlang-21.3.2_elixir-1.8.1_deps-dev.plt
Finding modules for dialyxir_erlang-21.3.2_elixir-1.8.1_deps-dev.plt
Copying dialyxir_erlang-21.3.2_elixir-1.8.1.plt to dialyxir_erlang-21.3.2_elixir-1.8.1_deps-dev.plt
Looking up modules in dialyxir_erlang-21.3.2_elixir-1.8.1_deps-dev.plt
Checking 420 modules in dialyxir_erlang-21.3.2_elixir-1.8.1_deps-dev.plt
Adding 322 modules to dialyxir_erlang-21.3.2_elixir-1.8.1_deps-dev.plt
Starting Dialyzer
[
  check_plt: false,
  init_plt: '/home/circleci/repo/_build/dev/dialyxir_erlang-21.3.2_elixir-1.8.1_deps-dev.plt',
  files_rec: ['/home/circleci/repo/_build/dev/lib/pipedrive/ebin'],
  warnings: [:unknown]
]
Total errors: 0, Skipped: 0
done in 0m1.05s
done (passed successfully)

real	3m43.637s
user	7m47.512s
sys	0m44.316s
```

</details>

<details>
  <summary>Dializer with an enabled PLT cache</summary>

```bash
#!/bin/bash -eo pipefail
time mix dialyzer --halt-exit-status
Finding suitable PLTs
Checking PLT...
[:credo, :dialyxir, :elixir, :ex_doc, :httpoison, :jason, :kernel, :logger, :stdlib]
PLT is up to date!
Starting Dialyzer
[
  check_plt: false,
  init_plt: '/home/circleci/repo/priv/plts/dialyzer.plt',
  files_rec: ['/home/circleci/repo/_build/dev/lib/pipedrive/ebin'],
  warnings: [:unknown]
]
Total errors: 0, Skipped: 0
done in 0m1.09s
done (passed successfully)

real	0m1.515s
user	0m2.188s
sys	0m0.372s
```

</details>

## How to detect erlang version for PLT cache key

I could not find an easy way to determine the erlang version in the CircleCI environment.
Apparently CircleCI staff [recommended](https://discuss.circleci.com/t/how-does-one-lock-down-a-certain-version-of-erlang/20355/3) to use docker to lock down a specific version of erlang.

I don't think we want to do that right now, so I used this snippet from this SO [answer](https://stackoverflow.com/a/34326368/10955714):

```bash
$ erl -eval '{ok, Version} = file:read_file(filename:join([code:root_dir(), "releases", erlang:system_info(otp_release), "OTP_VERSION"])), io:fwrite(Version), halt().' -noshell
21.0.8
```