### PR TITLE
Feature/add persons search and get

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ commands:
       - restore_cache:
           name: Restore PLT cache
           key: plt-cache-v1-{{ checksum "ERLANG_VERSION" }}-{{ checksum "ELIXIR_VERSION" }}
-      - run: mix dialyzer --halt-exit-status
+      - run: mix dialyzer
       - save_cache:
           name: Save PLT cache
           key: plt-cache-v1-{{ checksum "ERLANG_VERSION" }}-{{ checksum "ELIXIR_VERSION" }}

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ pipedrive-*.tar
 /priv/plts/*.plt.hash
 
 SCRATCHPAD.ex
+
+.vscode/

--- a/fixture/vcr_cassettes/persons_get.json
+++ b/fixture/vcr_cassettes/persons_get.json
@@ -1,0 +1,49 @@
+[
+  {
+    "request": {
+      "body": "",
+      "headers": {
+        "Content-Type": "application/json"
+      },
+      "method": "get",
+      "options": {
+        "follow_redirect": "true"
+      },
+      "request_body": "",
+      "url": "https://company-subdomain.pipedrive.com/v1/persons/23?api_token=[API_TOKEN_REMOVED]"
+    },
+    "response": {
+      "binary": false,
+      "body": "{\"success\":true,\"data\":{\"id\":23,\"company_id\":6862868,\"owner_id\":{\"id\":8091815,\"name\":\"Mihai Tarnovan\",\"email\":\"[EMAIL_REMOVED]\",\"has_pic\":1,\"pic_hash\":\"a22e1716123b7c5be851973bd362a2f3\",\"active_flag\":true,\"value\":8091815},\"org_id\":null,\"name\":\"Alice Aubree\",\"first_name\":\"Alice\",\"last_name\":\"Aubree\",\"open_deals_count\":3,\"related_open_deals_count\":0,\"closed_deals_count\":0,\"related_closed_deals_count\":0,\"participant_open_deals_count\":0,\"participant_closed_deals_count\":0,\"email_messages_count\":0,\"activities_count\":0,\"done_activities_count\":0,\"undone_activities_count\":0,\"files_count\":0,\"notes_count\":0,\"followers_count\":1,\"won_deals_count\":0,\"related_won_deals_count\":0,\"lost_deals_count\":0,\"related_lost_deals_count\":0,\"active_flag\":true,\"phone\":[{\"value\":\"\",\"primary\":true}],\"email\":[{\"label\":\"\",\"value\":\"alice@example.com\",\"primary\":true}],\"first_char\":\"a\",\"update_time\":\"2020-08-31 16:45:16\",\"add_time\":\"2020-01-31 10:14:14\",\"visible_to\":\"3\",\"picture_id\":null,\"next_activity_date\":null,\"next_activity_time\":null,\"next_activity_id\":null,\"last_activity_id\":null,\"last_activity_date\":null,\"last_incoming_mail_time\":null,\"last_outgoing_mail_time\":null,\"label\":null,\"d8a94a581ae3f15581b9905ffe3d802a60b27f9a\":\"Steady Automatic Export (dev Mihai)\",\"7777af00cf4c419c0f038f75cfb0fa4380f853fe\":\"911f0b5a-155c-4e17-a424-ceac3abd1b02\",\"8b6c01c11c35a95490d81bc665a929ff730c734a\":null,\"9360c1ee969747bc9f33762669ccf8f1325490ff\":null,\"df03d1a618f9b0be1880436102586656617640f8\":null,\"9d8325277a2d56ea352d6f1b7366f054a2fb3abf\":null,\"org_name\":null,\"cc_email\":\"[EMAIL_REMOVED]\",\"owner_name\":\"Mihai Tarnovan\"},\"additional_data\":{\"dropbox_email\":\"[EMAIL_REMOVED]\"},\"related_objects\":{\"user\":{\"8091815\":{\"id\":8091815,\"name\":\"Mihai Tarnovan\",\"email\":\"[EMAIL_REMOVED]\",\"has_pic\":1,\"pic_hash\":\"a22e1716123b7c5be851973bd362a2f3\",\"active_flag\":true}}}}",
+      "headers": {
+        "Date": "Tue, 01 Sep 2020 10:54:37 GMT",
+        "Content-Type": "application/json",
+        "Transfer-Encoding": "chunked",
+        "Connection": "keep-alive",
+        "Set-Cookie": "__cfduid=d37890f92b52c81e7c1c4ea432c9e06631598957677; expires=Thu, 01-Oct-20 10:54:37 GMT; path=/; domain=.pipedrive.com; HttpOnly; SameSite=Lax",
+        "CF-Ray": "5cbe7449ebd9ad1e-OTP",
+        "Access-Control-Allow-Origin": "*",
+        "Cache-Control": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "Vary": "Accept-Encoding",
+        "CF-Cache-Status": "DYNAMIC",
+        "Access-Control-Expose-Headers": "X-RateLimit-Remaining, X-RateLimit-Limit, X-RateLimit-Reset",
+        "badi": "Routing: eu-central-1=>eu-central-1; Version: c88a; Host: bari;",
+        "cf-request-id": "04eae7022c0000ad1ef69d9200000001",
+        "Expect-CT": "max-age=604800, report-uri=\"https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct\"",
+        "pdtrusted-wgw-real-user-ip": "5.15.246.253",
+        "x-content-type-options": "nosniff",
+        "x-correlation-id": "a85b1f38-40c1-4218-b9bd-6b1cd88396ca",
+        "x-frame-options": "SAMEORIGIN",
+        "X-RateLimit-Limit": "20",
+        "X-RateLimit-Remaining": "19",
+        "X-RateLimit-Reset": "2",
+        "X-XSS-Protection": "1; mode=block",
+        "Server": "cloudflare",
+        "alt-svc": "h3-27=\":443\"; ma=86400, h3-28=\":443\"; ma=86400, h3-29=\":443\"; ma=86400"
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  }
+]

--- a/fixture/vcr_cassettes/persons_get.json
+++ b/fixture/vcr_cassettes/persons_get.json
@@ -10,18 +10,18 @@
         "follow_redirect": "true"
       },
       "request_body": "",
-      "url": "https://company-subdomain.pipedrive.com/v1/persons/23?api_token=[API_TOKEN_REMOVED]"
+      "url": "https://company-subdomain.pipedrive.com/v1/persons/35?api_token=[API_TOKEN_REMOVED]"
     },
     "response": {
       "binary": false,
-      "body": "{\"success\":true,\"data\":{\"id\":23,\"company_id\":6862868,\"owner_id\":{\"id\":8091815,\"name\":\"Mihai Tarnovan\",\"email\":\"[EMAIL_REMOVED]\",\"has_pic\":1,\"pic_hash\":\"a22e1716123b7c5be851973bd362a2f3\",\"active_flag\":true,\"value\":8091815},\"org_id\":null,\"name\":\"Alice Aubree\",\"first_name\":\"Alice\",\"last_name\":\"Aubree\",\"open_deals_count\":3,\"related_open_deals_count\":0,\"closed_deals_count\":0,\"related_closed_deals_count\":0,\"participant_open_deals_count\":0,\"participant_closed_deals_count\":0,\"email_messages_count\":0,\"activities_count\":0,\"done_activities_count\":0,\"undone_activities_count\":0,\"files_count\":0,\"notes_count\":0,\"followers_count\":1,\"won_deals_count\":0,\"related_won_deals_count\":0,\"lost_deals_count\":0,\"related_lost_deals_count\":0,\"active_flag\":true,\"phone\":[{\"value\":\"\",\"primary\":true}],\"email\":[{\"label\":\"\",\"value\":\"alice@example.com\",\"primary\":true}],\"first_char\":\"a\",\"update_time\":\"2020-08-31 16:45:16\",\"add_time\":\"2020-01-31 10:14:14\",\"visible_to\":\"3\",\"picture_id\":null,\"next_activity_date\":null,\"next_activity_time\":null,\"next_activity_id\":null,\"last_activity_id\":null,\"last_activity_date\":null,\"last_incoming_mail_time\":null,\"last_outgoing_mail_time\":null,\"label\":null,\"d8a94a581ae3f15581b9905ffe3d802a60b27f9a\":\"Steady Automatic Export (dev Mihai)\",\"7777af00cf4c419c0f038f75cfb0fa4380f853fe\":\"911f0b5a-155c-4e17-a424-ceac3abd1b02\",\"8b6c01c11c35a95490d81bc665a929ff730c734a\":null,\"9360c1ee969747bc9f33762669ccf8f1325490ff\":null,\"df03d1a618f9b0be1880436102586656617640f8\":null,\"9d8325277a2d56ea352d6f1b7366f054a2fb3abf\":null,\"org_name\":null,\"cc_email\":\"[EMAIL_REMOVED]\",\"owner_name\":\"Mihai Tarnovan\"},\"additional_data\":{\"dropbox_email\":\"[EMAIL_REMOVED]\"},\"related_objects\":{\"user\":{\"8091815\":{\"id\":8091815,\"name\":\"Mihai Tarnovan\",\"email\":\"[EMAIL_REMOVED]\",\"has_pic\":1,\"pic_hash\":\"a22e1716123b7c5be851973bd362a2f3\",\"active_flag\":true}}}}",
+      "body": "{\"success\":true,\"data\":{\"id\":35,\"company_id\":6862868,\"owner_id\":{\"id\":8091815,\"name\":\"Mihai Tarnovan\",\"email\":\"[EMAIL_REMOVED]\",\"has_pic\":1,\"pic_hash\":\"a22e1716123b7c5be851973bd362a2f3\",\"active_flag\":true,\"value\":8091815},\"org_id\":null,\"name\":\"Alice Aubree\",\"first_name\":\"Alice\",\"last_name\":\"Aubree\",\"open_deals_count\":4,\"related_open_deals_count\":0,\"closed_deals_count\":0,\"related_closed_deals_count\":0,\"participant_open_deals_count\":0,\"participant_closed_deals_count\":0,\"email_messages_count\":0,\"activities_count\":0,\"done_activities_count\":0,\"undone_activities_count\":0,\"files_count\":0,\"notes_count\":0,\"followers_count\":1,\"won_deals_count\":0,\"related_won_deals_count\":0,\"lost_deals_count\":0,\"related_lost_deals_count\":0,\"active_flag\":true,\"phone\":[{\"value\":\"\",\"primary\":true}],\"email\":[{\"label\":\"\",\"value\":\"alice@example.com\",\"primary\":true}],\"first_char\":\"a\",\"update_time\":\"2020-09-01 12:48:58\",\"add_time\":\"2020-05-21 09:43:13\",\"visible_to\":\"3\",\"picture_id\":null,\"next_activity_date\":null,\"next_activity_time\":null,\"next_activity_id\":null,\"last_activity_id\":null,\"last_activity_date\":null,\"last_incoming_mail_time\":null,\"last_outgoing_mail_time\":null,\"label\":null,\"d8a94a581ae3f15581b9905ffe3d802a60b27f9a\":\"Steady Automatic Export (dev Mihai)\",\"7777af00cf4c419c0f038f75cfb0fa4380f853fe\":\"96e0749b-b370-46b2-9d26-37ca19a26bd9\",\"8b6c01c11c35a95490d81bc665a929ff730c734a\":\"https:\\/\\/localhost:4000\\/alices-podcast\",\"9360c1ee969747bc9f33762669ccf8f1325490ff\":\"fr\",\"df03d1a618f9b0be1880436102586656617640f8\":null,\"9d8325277a2d56ea352d6f1b7366f054a2fb3abf\":null,\"org_name\":null,\"cc_email\":\"[EMAIL_REMOVED]\",\"owner_name\":\"Mihai Tarnovan\"},\"additional_data\":{\"dropbox_email\":\"[EMAIL_REMOVED]\"},\"related_objects\":{\"user\":{\"8091815\":{\"id\":8091815,\"name\":\"Mihai Tarnovan\",\"email\":\"[EMAIL_REMOVED]\",\"has_pic\":1,\"pic_hash\":\"a22e1716123b7c5be851973bd362a2f3\",\"active_flag\":true}}}}",
       "headers": {
-        "Date": "Tue, 01 Sep 2020 10:54:37 GMT",
+        "Date": "Tue, 01 Sep 2020 12:51:57 GMT",
         "Content-Type": "application/json",
         "Transfer-Encoding": "chunked",
         "Connection": "keep-alive",
-        "Set-Cookie": "__cfduid=d37890f92b52c81e7c1c4ea432c9e06631598957677; expires=Thu, 01-Oct-20 10:54:37 GMT; path=/; domain=.pipedrive.com; HttpOnly; SameSite=Lax",
-        "CF-Ray": "5cbe7449ebd9ad1e-OTP",
+        "Set-Cookie": "__cfduid=dd88f0bce1624ac3a1f097fc75031a6801598964717; expires=Thu, 01-Oct-20 12:51:57 GMT; path=/; domain=.pipedrive.com; HttpOnly; SameSite=Lax",
+        "CF-Ray": "5cbf202a790facbe-OTP",
         "Access-Control-Allow-Origin": "*",
         "Cache-Control": "no-cache",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
@@ -29,11 +29,11 @@
         "CF-Cache-Status": "DYNAMIC",
         "Access-Control-Expose-Headers": "X-RateLimit-Remaining, X-RateLimit-Limit, X-RateLimit-Reset",
         "badi": "Routing: eu-central-1=>eu-central-1; Version: c88a; Host: bari;",
-        "cf-request-id": "04eae7022c0000ad1ef69d9200000001",
+        "cf-request-id": "04eb526e8b0000acbebc337200000001",
         "Expect-CT": "max-age=604800, report-uri=\"https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct\"",
         "pdtrusted-wgw-real-user-ip": "5.15.246.253",
         "x-content-type-options": "nosniff",
-        "x-correlation-id": "a85b1f38-40c1-4218-b9bd-6b1cd88396ca",
+        "x-correlation-id": "4cc4e749-e463-4eab-9718-643bc001f820",
         "x-frame-options": "SAMEORIGIN",
         "X-RateLimit-Limit": "20",
         "X-RateLimit-Remaining": "19",

--- a/fixture/vcr_cassettes/persons_search.json
+++ b/fixture/vcr_cassettes/persons_search.json
@@ -1,0 +1,48 @@
+[
+  {
+    "request": {
+      "body": "",
+      "headers": {
+        "Content-Type": "application/json"
+      },
+      "method": "get",
+      "options": {
+        "follow_redirect": "true"
+      },
+      "request_body": "",
+      "url": "https://company-subdomain.pipedrive.com/v1/persons/search?api_token=[API_TOKEN_REMOVED]&exact_match=true&fields=custom_fields&term=911f0b5a-155c-4e17-a424-ceac3abd1b02"
+    },
+    "response": {
+      "binary": false,
+      "body": "{\"success\":true,\"data\":{\"items\":[{\"result_score\":0.1997,\"item\":{\"id\":23,\"type\":\"person\",\"name\":\"Alice Aubree\",\"phones\":[],\"emails\":[\"alice@example.com\"],\"visible_to\":3,\"owner\":{\"id\":8091815},\"organization\":null,\"custom_fields\":[\"Steady Automatic Export (dev Mihai)\",\"911f0b5a-155c-4e17-a424-ceac3abd1b02\"],\"notes\":[]}}]},\"additional_data\":{\"pagination\":{\"start\":0,\"limit\":100,\"more_items_in_collection\":false}}}",
+      "headers": {
+        "Date": "Tue, 01 Sep 2020 10:46:57 GMT",
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "411",
+        "Connection": "keep-alive",
+        "Set-Cookie": "__cfduid=d442e9a1972726c0a40a4e21c1d69a8c61598957217; expires=Thu, 01-Oct-20 10:46:57 GMT; path=/; domain=.pipedrive.com; HttpOnly; SameSite=Lax",
+        "CF-Ray": "5cbe690fabcfad30-OTP",
+        "Accept-Ranges": "bytes",
+        "Access-Control-Allow-Origin": "*",
+        "Cache-Control": "no-cache",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "CF-Cache-Status": "DYNAMIC",
+        "Access-Control-Expose-Headers": "X-RateLimit-Remaining, X-RateLimit-Limit, X-RateLimit-Reset",
+        "badi": "Routing: eu-central-1=>eu-central-1; Version: c88a; Host: bari;",
+        "cf-request-id": "04eadffdc60000ad30469ee200000001",
+        "Expect-CT": "max-age=604800, report-uri=\"https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct\"",
+        "pdtrusted-wgw-real-user-ip": "5.15.246.253",
+        "X-Content-Type-Options": "nosniff",
+        "x-correlation-id": "600985f7-06c1-4dea-b962-a5261684645b",
+        "X-RateLimit-Limit": "20",
+        "X-RateLimit-Remaining": "19",
+        "X-RateLimit-Reset": "2",
+        "X-XSS-Protection": "1; mode=block",
+        "Server": "cloudflare",
+        "alt-svc": "h3-27=\":443\"; ma=86400, h3-28=\":443\"; ma=86400, h3-29=\":443\"; ma=86400"
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  }
+]

--- a/fixture/vcr_cassettes/persons_search.json
+++ b/fixture/vcr_cassettes/persons_search.json
@@ -10,18 +10,18 @@
         "follow_redirect": "true"
       },
       "request_body": "",
-      "url": "https://company-subdomain.pipedrive.com/v1/persons/search?api_token=[API_TOKEN_REMOVED]&exact_match=true&fields=custom_fields&term=911f0b5a-155c-4e17-a424-ceac3abd1b02"
+      "url": "https://company-subdomain.pipedrive.com/v1/persons/search?api_token=[API_TOKEN_REMOVED]&exact_match=true&fields=custom_fields&term=96e0749b-b370-46b2-9d26-37ca19a26bd9"
     },
     "response": {
       "binary": false,
-      "body": "{\"success\":true,\"data\":{\"items\":[{\"result_score\":0.1997,\"item\":{\"id\":23,\"type\":\"person\",\"name\":\"Alice Aubree\",\"phones\":[],\"emails\":[\"alice@example.com\"],\"visible_to\":3,\"owner\":{\"id\":8091815},\"organization\":null,\"custom_fields\":[\"Steady Automatic Export (dev Mihai)\",\"911f0b5a-155c-4e17-a424-ceac3abd1b02\"],\"notes\":[]}}]},\"additional_data\":{\"pagination\":{\"start\":0,\"limit\":100,\"more_items_in_collection\":false}}}",
+      "body": "{\"success\":true,\"data\":{\"items\":[{\"result_score\":0.1997,\"item\":{\"id\":35,\"type\":\"person\",\"name\":\"Alice Aubree\",\"phones\":[],\"emails\":[\"alice@example.com\"],\"visible_to\":3,\"owner\":{\"id\":8091815},\"organization\":null,\"custom_fields\":[\"Steady Automatic Export (dev Mihai)\",\"96e0749b-b370-46b2-9d26-37ca19a26bd9\",\"https://localhost:4000/alices-podcast\",\"fr\"],\"notes\":[]}}]},\"additional_data\":{\"pagination\":{\"start\":0,\"limit\":100,\"more_items_in_collection\":false}}}",
       "headers": {
-        "Date": "Tue, 01 Sep 2020 10:46:57 GMT",
+        "Date": "Tue, 01 Sep 2020 12:51:53 GMT",
         "Content-Type": "application/json; charset=utf-8",
-        "Content-Length": "411",
+        "Content-Length": "456",
         "Connection": "keep-alive",
-        "Set-Cookie": "__cfduid=d442e9a1972726c0a40a4e21c1d69a8c61598957217; expires=Thu, 01-Oct-20 10:46:57 GMT; path=/; domain=.pipedrive.com; HttpOnly; SameSite=Lax",
-        "CF-Ray": "5cbe690fabcfad30-OTP",
+        "Set-Cookie": "__cfduid=d6c05d976a7cc1bdb1c874a0e1411e9501598964713; expires=Thu, 01-Oct-20 12:51:53 GMT; path=/; domain=.pipedrive.com; HttpOnly; SameSite=Lax",
+        "CF-Ray": "5cbf201208092918-OTP",
         "Accept-Ranges": "bytes",
         "Access-Control-Allow-Origin": "*",
         "Cache-Control": "no-cache",
@@ -29,11 +29,11 @@
         "CF-Cache-Status": "DYNAMIC",
         "Access-Control-Expose-Headers": "X-RateLimit-Remaining, X-RateLimit-Limit, X-RateLimit-Reset",
         "badi": "Routing: eu-central-1=>eu-central-1; Version: c88a; Host: bari;",
-        "cf-request-id": "04eadffdc60000ad30469ee200000001",
+        "cf-request-id": "04eb525f470000291895917200000001",
         "Expect-CT": "max-age=604800, report-uri=\"https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct\"",
         "pdtrusted-wgw-real-user-ip": "5.15.246.253",
         "X-Content-Type-Options": "nosniff",
-        "x-correlation-id": "600985f7-06c1-4dea-b962-a5261684645b",
+        "x-correlation-id": "e0c2a7f3-c53a-4e91-a5bc-aa5fd5f0b89a",
         "X-RateLimit-Limit": "20",
         "X-RateLimit-Remaining": "19",
         "X-RateLimit-Reset": "2",

--- a/lib/pipedrive/helpers/rate_limit.ex
+++ b/lib/pipedrive/helpers/rate_limit.ex
@@ -35,7 +35,7 @@ defmodule Pipedrive.Helpers.RateLimit do
   end
 
   defp execute_request(api_call, api_call_args) do
-    case apply(api_call, api_call_args) do
+    case apply(api_call, List.wrap(api_call_args)) do
       {:ok, response} ->
         {:ok, response}
 

--- a/lib/pipedrive/persons.ex
+++ b/lib/pipedrive/persons.ex
@@ -9,7 +9,7 @@ defmodule Pipedrive.Persons do
   import Pipedrive, only: [api_docs_base_url: 0]
 
   @doc """
-  Get all deals.
+  Get all persons.
 
   [Pipedrive API docs](#{api_docs_base_url()}/Persons/get_persons)
   """
@@ -17,6 +17,17 @@ defmodule Pipedrive.Persons do
   @spec list(Keyword.t()) :: API.response()
   def list(opts \\ []) do
     API.get("/persons", "", opts)
+  end
+
+  @doc """
+  Get person by ID.
+
+  [Pipedrive API docs](#{api_docs_base_url()}/Persons/get_persons_id)
+  """
+  @impl Pipedrive.RESTEntity
+  @spec get(String.t(), Keyword.t()) :: API.response()
+  def get(id, opts \\ []) do
+    API.get("/persons/#{id}", "", opts)
   end
 
   @doc """
@@ -65,5 +76,16 @@ defmodule Pipedrive.Persons do
   @spec delete_bulk(nonempty_list(String.t()), Keyword.t()) :: API.response()
   def delete_bulk(ids, opts \\ []) do
     API.delete("/persons", %{ids: serialize_ids(ids)}, opts)
+  end
+
+  @doc """
+  Search a person
+
+  [Pipedrive API docs](#{api_docs_base_url()}/Persons/get_persons_search)
+  """
+  @impl Pipedrive.RESTEntity
+  @spec search(Keyword.t()) :: API.response()
+  def search(opts \\ []) do
+    API.get("/persons/search", "", opts)
   end
 end

--- a/lib/pipedrive/rest_entity.ex
+++ b/lib/pipedrive/rest_entity.ex
@@ -21,7 +21,7 @@ defmodule Pipedrive.RESTEntity do
   @callback delete_bulk(nonempty_list(String.t())) :: API.response()
   @callback delete_bulk(nonempty_list(String.t()), Keyword.t()) :: API.response()
 
-  @callback search(map()) :: API.response()
+  @callback search(Keyword.t()) :: API.response()
 
   @optional_callbacks search: 1, get: 1, get: 2
 end

--- a/lib/pipedrive/rest_entity.ex
+++ b/lib/pipedrive/rest_entity.ex
@@ -6,6 +6,9 @@ defmodule Pipedrive.RESTEntity do
   @callback list() :: API.response()
   @callback list(Keyword.t()) :: API.response()
 
+  @callback get(String.t()) :: API.response()
+  @callback get(String.t(), Keyword.t()) :: API.response()
+
   @callback create(map()) :: API.response()
   @callback create(map(), Keyword.t()) :: API.response()
 
@@ -17,4 +20,8 @@ defmodule Pipedrive.RESTEntity do
 
   @callback delete_bulk(nonempty_list(String.t())) :: API.response()
   @callback delete_bulk(nonempty_list(String.t()), Keyword.t()) :: API.response()
+
+  @callback search(map()) :: API.response()
+
+  @optional_callbacks search: 1, get: 1, get: 2
 end

--- a/test/pipedrive/persons_test.exs
+++ b/test/pipedrive/persons_test.exs
@@ -69,19 +69,19 @@ defmodule Pipedrive.Test.Persons do
       {:ok, %{"data" => data}} =
         Persons.search(
           url_params: %{
-            term: "911f0b5a-155c-4e17-a424-ceac3abd1b02",
+            term: "96e0749b-b370-46b2-9d26-37ca19a26bd9",
             exact_match: true,
             fields: :custom_fields
           }
         )
 
-      assert match?(%{"items" => [%{"item" => %{"id" => 23, "name" => "Alice Aubree"}}]}, data)
+      assert match?(%{"items" => [%{"item" => %{"id" => 35, "name" => "Alice Aubree"}}]}, data)
     end
   end
 
   test "get a person" do
     use_cassette "persons_get", match_requests_on: [:query] do
-      assert match?({:ok, %{"data" => %{"id" => 23, "name" => "Alice Aubree"}}}, Persons.get(23))
+      assert match?({:ok, %{"data" => %{"id" => 35, "name" => "Alice Aubree"}}}, Persons.get(35))
     end
   end
 end

--- a/test/pipedrive/persons_test.exs
+++ b/test/pipedrive/persons_test.exs
@@ -74,6 +74,7 @@ defmodule Pipedrive.Test.Persons do
             fields: :custom_fields
           }
         )
+
       assert match?(%{"items" => [%{"item" => %{"id" => 23, "name" => "Alice Aubree"}}]}, data)
     end
   end

--- a/test/pipedrive/persons_test.exs
+++ b/test/pipedrive/persons_test.exs
@@ -63,4 +63,24 @@ defmodule Pipedrive.Test.Persons do
       refute Enum.find(data, &(&1["id"] == id3))
     end
   end
+
+  test "search a person" do
+    use_cassette "persons_search", match_requests_on: [:query] do
+      {:ok, %{"data" => data}} =
+        Persons.search(
+          url_params: %{
+            term: "911f0b5a-155c-4e17-a424-ceac3abd1b02",
+            exact_match: true,
+            fields: :custom_fields
+          }
+        )
+      assert match?(%{"items" => [%{"item" => %{"id" => 23, "name" => "Alice Aubree"}}]}, data)
+    end
+  end
+
+  test "get a person" do
+    use_cassette "persons_get", match_requests_on: [:query] do
+      assert match?({:ok, %{"data" => %{"id" => 23, "name" => "Alice Aubree"}}}, Persons.get(23))
+    end
+  end
 end


### PR DESCRIPTION
This is in support of a drive-by change while working on https://steadymedia.atlassian.net/browse/SD-433, not directly related to the ticket: refactoring `Ypsilon.Pipedrive.Person.get_by_user_id` to use a search + a get instead of fetching all persons.